### PR TITLE
Mono fixes

### DIFF
--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -84,7 +84,9 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 if String.IsNullOrEmpty(resolutionPath) || resolutionPath = @"\"
                 then runtimeAssembly
                 else resolutionPath
-            let connectionString = connectionString.Replace(@".\", basePath + @"\")
+            let connectionString = 
+                connectionString.Replace(@".\", basePath + @"\") 
+                |> ConfigHelpers.parseConnectionString
             Activator.CreateInstance(connectionType,[|box connectionString|]) :?> IDbConnection
         member __.CreateCommand(connection,commandText) = Activator.CreateInstance(commandType,[|box commandText;box connection|]) :?> IDbCommand
         member __.CreateCommandParameter(param,value) = 

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -179,6 +179,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 let relProps = 
                     let bts = baseTypes.Force()       
                     [ for r in children do               
+                       if bts.ContainsKey(r.ForeignTable) then
                         let (tt,_,_,_) = (bts.[r.ForeignTable])
                         let ty = typedefof<System.Linq.IQueryable<_>>
                         let ty = ty.MakeGenericType tt
@@ -192,6 +193,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         prop.AddXmlDoc(sprintf "Related %s entities from the foreign side of the relationship, where the primary key is %s and the foreign key is %s" r.ForeignTable r.PrimaryKey r.ForeignKey)
                         yield prop ] @
                     [ for r in parents do
+                       if bts.ContainsKey(r.PrimaryTable) then
                         let (tt,_,_,_) = (bts.[r.PrimaryTable])
                         let ty = typedefof<System.Linq.IQueryable<_>>
                         let ty = ty.MakeGenericType tt

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -64,6 +64,21 @@ module ConfigHelpers =
             | None -> None
         else Some(connectionString)
 
+    let parseConnectionString conn =
+        let isMono = (Type.GetType "Mono.Runtime") <> null
+        let builder = System.Data.Common.DbConnectionStringBuilder()
+        builder.ConnectionString <- conn
+        match builder.ContainsKey "data source" with
+        | false -> conn
+        | true ->
+            let ds = builder.["data source"].ToString()
+            if isMono then
+                builder.["data source"] <- ds.Replace(@"\", "/")
+            else
+                builder.["data source"] <- ds.Replace("/", @"\")
+            builder.ConnectionString
+
+
 module internal SchemaProjections = 
     
     //Creatviely taken from FSharp.Data (https://github.com/fsharp/FSharp.Data/blob/master/src/CommonRuntime/NameUtils.fs)

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -6,9 +6,11 @@ open System.Linq
 open NUnit.Framework
 
 [<Literal>]
-let connectionString = @"Data Source=.\db\northwindEF.db; Version = 3; Read Only=true; FailIfMissing=True;"
+let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + "/db/northwindEF.db; Version = 3; Read Only=true; FailIfMissing=True;"
+[<Literal>]
+let resolutionPath = __SOURCE_DIRECTORY__ + "\libs"
 
-type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString>
+type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString,  ResolutionPath = resolutionPath>
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %s")
    
 [<Test; Ignore("Not Supported")>]

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -8,7 +8,7 @@ open NUnit.Framework
 [<Literal>]
 let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + "/db/northwindEF.db; Version = 3; Read Only=true; FailIfMissing=True;"
 [<Literal>]
-let resolutionPath = __SOURCE_DIRECTORY__ + "\libs"
+let resolutionPath = __SOURCE_DIRECTORY__ + @"\libs"
 
 type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString,  ResolutionPath = resolutionPath>
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %s")

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -68,7 +68,7 @@ let topSales5ByCommission =
     |> Seq.map (fun e -> e.MapTo<Employee>())
     |> Seq.toList
 
-#r @"..\..\..\packages\Newtonsoft.Json\lib\net45\Newtonsoft.Json.dll"
+#r @"../../../packages/Newtonsoft.Json/lib/net45/Newtonsoft.Json.dll"
 
 open Newtonsoft.Json
 

--- a/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
@@ -7,7 +7,7 @@ open FSharp.Data.Sql
 let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"\..\db\northwindEF.db;Version=3"
 
 [<Literal>]
-let resolutionPath = __SOURCE_DIRECTORY__ + "\..\libs"
+let resolutionPath = __SOURCE_DIRECTORY__ + @"\..\libs"
 
 
 open FSharp.Data.Sql

--- a/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
@@ -4,7 +4,7 @@ open System
 open FSharp.Data.Sql
 
 [<Literal>]
-let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"\northwindEF.db;Version=3"
+let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"\..\db\northwindEF.db;Version=3"
 
 [<Literal>]
 let resolutionPath = __SOURCE_DIRECTORY__ + "\..\libs"


### PR DESCRIPTION
Ok, the real problem wasn't the SQLProvider, it was actually MySQL/MariaDB:

- MySQL is Case Insensitive in Windows.
- MySQL is Case Sensitive in Mac/Linux.

This is due to file system differences. Anyways I wanted to be able to use the same F# source code using MySQL from Windows and Linux and now it is possible. I didn't test if LOWER-conversion would somehow causing not-hitting-the-table-index (while I know that this would be the case with Oracle) but the conversion is done by compile-time queries to system tables; and who would use 10000 column system tables with the MySQL so it probably doesn't matter. The table names shown to the user are still in the right case.

Also fixed the delete command parameter name.

This will fix issue fsprojects/SQLProvider#140